### PR TITLE
Fix scrolling of tables on UI

### DIFF
--- a/templates/ui.tmpl
+++ b/templates/ui.tmpl
@@ -16,6 +16,7 @@
                 border-radius: 15px;
                 padding-bottom: 10px;
                 width: 90%;
+                overflow-x: auto;
                 margin-bottom: 25px;
             }
 
@@ -27,7 +28,6 @@
                 border-collapse: collapse;
                 border-top-left-radius: 15px;
                 width: 100%;
-                overflow-x: scroll;
             }
 
             th {


### PR DESCRIPTION
Currently the table just extends off of the page if the screen is not wide enough. This fixes it by causing it to scroll on the x if it overflows.